### PR TITLE
Naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,26 +49,26 @@ Install-Package Firefly.DependencyInjection
 
 ## Basic Setup
 
-During application startup, find a `IServiceCollection` instance and call `SetupFireflyServiceRegistration()`.
+During application startup, find a `IServiceCollection` instance and call `AddFireflyServiceRegistration()`.
 
 The location depends on your [Hosting Model](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/webapplication?view=aspnetcore-7.0):
 
 #### WebApplicationBuilder
 ```cs
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.SetupFireflyServiceRegistration();
+builder.Services.AddFireflyServiceRegistration();
 ```
 #### Older Startup.cs
 ```csharp
 public virtual void ConfigureServices(IServiceCollection services)
 {
-    services.SetupFireflyServiceRegistration();
+    services.AddFireflyServiceRegistration();
 }
 ```
 #### Manually created ServiceCollction 
 ```csharp
 var sc = new ServiceCollection()
-sc.SetupFireflyServiceRegistration();
+sc.AddFireflyServiceRegistration();
 ```
 ---
 
@@ -144,7 +144,7 @@ Application startup:
 ```csharp
 var useLocalFiles = true;
 
-services.SetupFireflyServiceRegistration(builder => {
+services.AddFireflyServiceRegistration(builder => {
     if (useLocalFiles)
         builder.PickSingleImplementation<IFileProvider>(typeof(LocalFileProvider));
     else
@@ -177,7 +177,7 @@ It's fully possible to include another assembly. All these assemblies will be sc
 #### ⚠ Referencing an assembly is needed if you want to register services from another project in your solution.
 
 ```csharp
-services.SetupFireflyServiceRegistration(builder => {
+services.AddFireflyServiceRegistration(builder => {
     builder.UseAssembly("Example.Assembly.Name"); // Locate assembly by string
     builder.UseAssembly(Assembly.GetEntryAssembly()); // Specify assembly by the Assembly type and pass anything you need.
 });

--- a/src/Binder.cs
+++ b/src/Binder.cs
@@ -43,7 +43,7 @@ internal class Binder
 		{
 			if (false == RegistrationEntries.Any(x => x.ObjectType == concreteType && x.OuterType == interfaceType))
 				throw new ArgumentException($"No implementation of {concreteType} : {interfaceType} has been found.\n" +
-				                            $" This binding had been declared by `PickSingleImplementation` method in SetupFireflyServiceRegistration.\n" +
+				                            $" This binding had been declared by `PickSingleImplementation` method in AddFireflyServiceRegistration.\n" +
 				                            $" Note that the {interfaceType} must be set as Type parameter in the attribute, ie.:\n" +
 				                            $" [RegisterScoped(Type = typeof({interfaceType.Name})]");
 		}

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -7,10 +7,10 @@ namespace Firefly.DependencyInjection
 {
 	public static class ServiceCollectionExtensions
 	{
-		public static void SetupFireflyServiceRegistration(this IServiceCollection me)
-			=> SetupFireflyServiceRegistration(me, _ => { });
+		public static void AddFireflyServiceRegistration(this IServiceCollection me)
+			=> AddFireflyServiceRegistration(me, _ => { });
 
-		public static void SetupFireflyServiceRegistration(this IServiceCollection me,
+		public static void AddFireflyServiceRegistration(this IServiceCollection me,
 			Action<DiRegistrationBuilder> builder)
 		{
 			try

--- a/tests/Tests.cs
+++ b/tests/Tests.cs
@@ -13,14 +13,14 @@ namespace Firefly.DependencyInjection.Tests
 			// is not "Firefly.DependencyInjection.Tests" but some internal IDE test runner namespace.
 
 			// var sc = new ServiceCollection();
-			// sc.SetupFireflyServiceRegistration();
+			// sc.AddFireflyServiceRegistration();
 		}
 
 		[Fact]
 		public void TestAssemblyLoad()
 		{
 			var sc = new ServiceCollection();
-			sc.SetupFireflyServiceRegistration(builder =>
+			sc.AddFireflyServiceRegistration(builder =>
 			{
 				builder.UseAssembly("Firefly.DependencyInjection.Tests");
 				Assert.NotEmpty(builder.GetUsedAssemblies());
@@ -63,7 +63,7 @@ namespace Firefly.DependencyInjection.Tests
 		public void TestSingleAndMultiInstance()
 		{
 			var sc = new ServiceCollection();
-			sc.SetupFireflyServiceRegistration(builder =>
+			sc.AddFireflyServiceRegistration(builder =>
 			{
 				builder
 					.UseAssembly("Firefly.DependencyInjection.Tests")
@@ -85,7 +85,7 @@ namespace Firefly.DependencyInjection.Tests
 			
 			// Missing implementation of PickSingleImplementation
 			Assert.ThrowsAny<RegistrationBuilderException>(() =>
-				sc.SetupFireflyServiceRegistration(builder =>
+				sc.AddFireflyServiceRegistration(builder =>
 				{
 					builder
 						.UseAssembly("Firefly.DependencyInjection.Tests")
@@ -96,7 +96,7 @@ namespace Firefly.DependencyInjection.Tests
 			
 			// Multiple "PickSingleImplementation" for same interface
 			Assert.ThrowsAny<RegistrationBuilderException>(() =>
-				sc.SetupFireflyServiceRegistration(builder =>
+				sc.AddFireflyServiceRegistration(builder =>
 				{
 					builder
 						.UseAssembly("Firefly.DependencyInjection.Tests")


### PR DESCRIPTION
Renamed the `SetupFireflyServiceRegistration()` extension method to `AddFireflyServiceRegistration()` to be compliant with official naming conventions

https://learn.microsoft.com/en-us/dotnet/core/extensions/options-library-authors#naming-conventions